### PR TITLE
Add packages.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,9 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+  - package: dbt-labs/codegen
+    version: 0.12.1
+  - package: calogica/dbt_expectations
+    version: 0.10.3
+  - package: elementary-data/elementary
+    version: 0.14.1


### PR DESCRIPTION
 When you run dbt deps, dbt installs everything listed into the dbt_packages/ directory, leverage widely used packages like dbt-utils, dbt-expectations, or integrations like dbt-metabase